### PR TITLE
Fix doc: symbol for creating events is "at" not "ampersand"

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ first line.
 
 ## Events
 You may add an event to the calendar by adding a line to a diary entry
-which begins with an ampersand followed by a time and an event title.
+which begins with an "at" symbol followed by a time and an event title.
 
     @ 10:30 Dentist
 
 An event will be added to the calendar when the entry is saved. A
-colon will be added after the ampersand when the event has been added.
+colon will be added after the "at" symbol when the event has been added.
 
     @: 10:30 Dentist
 

--- a/data/help.md
+++ b/data/help.md
@@ -87,12 +87,12 @@ the first line.
 
 ## Events
 You may add an event to the calendar by adding a line to a diary entry
-which begins with an ampersand followed by a time and an event title.
+which begins with an "at" symbol followed by a time and an event title.
 
     @ 10:30 Dentist
 
 An event will be added to the calendar when the entry is saved. A
-colon will be added after the ampersand when the event has been added.
+colon will be added after the "at" symbol when the event has been added.
 
     @: 10:30 Dentist
 

--- a/src/main/assets/help.md
+++ b/src/main/assets/help.md
@@ -87,12 +87,12 @@ the first line.
 
 ## Events
 You may add an event to the calendar by adding a line to a diary entry
-which begins with an ampersand followed by a time and an event title.
+which begins with an "at" symbol followed by a time and an event title.
 
     @ 10:30 Dentist
 
 An event will be added to the calendar when the entry is saved. A
-colon will be added after the ampersand when the event has been added.
+colon will be added after the "at" symbol when the event has been added.
 
     @: 10:30 Dentist
 


### PR DESCRIPTION
I found a mistake in the documentation: it is said that the symbol used to create events is "ampersand" (i.e. "&"). But in fact, it is the "at" symbol (as shown in the examples).